### PR TITLE
Configure plugin only when aiven-prefixed keys are present

### DIFF
--- a/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryPlugin.java
+++ b/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryPlugin.java
@@ -37,7 +37,7 @@ import org.elasticsearch.repositories.Repository;
 
 public class GcsRepositoryPlugin extends Plugin implements RepositoryPlugin, ReloadablePlugin {
 
-    private final GcsSettingsProvider gcsSettingsProvider;
+    final GcsSettingsProvider gcsSettingsProvider;
 
     public GcsRepositoryPlugin(final Settings settings) {
         this.gcsSettingsProvider = new GcsSettingsProvider();
@@ -76,10 +76,16 @@ public class GcsRepositoryPlugin extends Plugin implements RepositoryPlugin, Rel
 
     @Override
     public void reload(final Settings settings) {
-        try {
-            gcsSettingsProvider.reload(settings);
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
+        // configure plugin only in case we have
+        // settings with prefix aiven
+        // FIXME maybe better approach exists, with getByPrefix()
+        final var hasAivenKeys = !settings.filter(key -> key.startsWith("aiven.")).isEmpty();
+        if (hasAivenKeys) {
+            try {
+                gcsSettingsProvider.reload(settings);
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 

--- a/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsSettingsProvider.java
+++ b/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsSettingsProvider.java
@@ -18,6 +18,7 @@ package io.aiven.elasticsearch.repositories.gcs;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 import io.aiven.elasticsearch.repositories.Permissions;
 import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
@@ -36,11 +37,19 @@ public class GcsSettingsProvider {
 
     private volatile Tuple<Storage, EncryptionKeyProvider> cachedSettings;
 
-    public Storage gcsClient() {
+    public Storage gcsClient() throws IOException {
+        //we should throw IOException for such action. ES swallows others
+        if (Objects.isNull(cachedSettings) || Objects.isNull(cachedSettings.x())) {
+            throw new IOException("GCS client hasn't been configured");
+        }
         return cachedSettings.x();
     }
 
-    public EncryptionKeyProvider encryptionKeyProvider() {
+    public EncryptionKeyProvider encryptionKeyProvider() throws IOException {
+        //we should throw IOException for such action. ES swallows others
+        if (Objects.isNull(cachedSettings) || Objects.isNull(cachedSettings.y())) {
+            throw new IOException("EncryptionKeyProvider hasn't been configured");
+        }
         return cachedSettings.y();
     }
 

--- a/src/test/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryPluginTest.java
+++ b/src/test/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryPluginTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.elasticsearch.repositories.gcs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import io.aiven.elasticsearch.repositories.DummySecureSettings;
+import io.aiven.elasticsearch.repositories.RsaKeyAwareTest;
+import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
+
+import org.elasticsearch.common.settings.Settings;
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GcsRepositoryPluginTest extends RsaKeyAwareTest {
+
+    @Test
+    void skipNonAivenSettings() throws Exception {
+        var plugin = new GcsRepositoryPlugin(Settings.EMPTY);
+        assertThrows(IOException.class, plugin.gcsSettingsProvider::encryptionKeyProvider);
+        assertThrows(IOException.class, plugin.gcsSettingsProvider::gcsClient);
+
+        plugin = new GcsRepositoryPlugin(
+                Settings.builder()
+                        .put("some_prop#0", "some_value#0")
+                        .put("some_prop#1", "some_value#1")
+                        .put("some_prop#2", "some_value#2")
+                        .build());
+        assertThrows(IOException.class, plugin.gcsSettingsProvider::encryptionKeyProvider);
+        assertThrows(IOException.class, plugin.gcsSettingsProvider::gcsClient);
+    }
+
+    @Test
+    void applyAivenSettings() throws Exception {
+
+        final var plugin =
+                new GcsRepositoryPlugin(Settings.builder()
+                        .setSecureSettings(createFullSecureSettings()).build());
+
+        assertNotNull(plugin.gcsSettingsProvider.encryptionKeyProvider());
+        assertNotNull(plugin.gcsSettingsProvider.gcsClient());
+    }
+
+    private DummySecureSettings createFullSecureSettings() throws IOException {
+        return new DummySecureSettings()
+                .setFile(
+                        GcsStorageSettings.CREDENTIALS_FILE_SETTING.getKey(),
+                        getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"))
+                .setFile(EncryptionKeyProvider.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem))
+                .setFile(EncryptionKeyProvider.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem));
+    }
+
+
+}


### PR DESCRIPTION
Plugin now cofigs only if aiven-prefixes keys have been set,
which prevents ES to be failed for empty keys.