### PR TITLE
Add support for io_buffer_size

### DIFF
--- a/repository-commons/src/test/java/io/aiven/elasticsearch/repositories/io/CryptoIOProviderTest.java
+++ b/repository-commons/src/test/java/io/aiven/elasticsearch/repositories/io/CryptoIOProviderTest.java
@@ -49,7 +49,7 @@ public class CryptoIOProviderTest extends RsaKeyAwareTest {
                         Files.newInputStream(privateKeyPem)
                 );
         final var encryptionKey = encProvider.createKey();
-        cryptoIOProvider = new CryptoIOProvider(encryptionKey);
+        cryptoIOProvider = new CryptoIOProvider(encryptionKey, BUFFER_SIZE);
     }
 
     @Test


### PR DESCRIPTION
Defauilt ES io_buffer_size property for repostipory settings gives possibility
to change buffer size during encryption. Default value is 128KB,
maximum - 8MB