### PR TITLE
Unique RSA public and private key settings

### DIFF
--- a/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/AbstractRepositoryPlugin.java
+++ b/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/AbstractRepositoryPlugin.java
@@ -18,13 +18,9 @@ package io.aiven.elasticsearch.repositories;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -57,16 +53,6 @@ public abstract class AbstractRepositoryPlugin<C>
     }
 
     @Override
-    public final List<Setting<?>> getSettings() {
-        final var encKeysSettings =
-                List.of(EncryptionKeyProvider.PUBLIC_KEY_FILE, EncryptionKeyProvider.PRIVATE_KEY_FILE);
-        return Stream.concat(
-                encKeysSettings.stream(),
-                getPluginSettings().stream()
-        ).collect(Collectors.toList());
-    }
-
-    @Override
     public Map<String, Repository.Factory> getRepositories(final Environment env,
                                                            final NamedXContentRegistry namedXContentRegistry,
                                                            final ClusterService clusterService,
@@ -93,7 +79,5 @@ public abstract class AbstractRepositoryPlugin<C>
             throw new UncheckedIOException(ioe);
         }
     }
-
-    protected abstract List<Setting<?>> getPluginSettings();
 
 }

--- a/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/RepositorySettingsProvider.java
+++ b/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/RepositorySettingsProvider.java
@@ -19,8 +19,6 @@ package io.aiven.elasticsearch.repositories;
 import java.io.IOException;
 import java.util.Objects;
 
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
-
 import org.elasticsearch.common.settings.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,22 +40,16 @@ public abstract class RepositorySettingsProvider<T> {
         if (settings.isEmpty()) {
             return;
         }
+
         try {
             LOGGER.info("Reload settings for repository type: {}", repositoryType);
-            final var encryptionKeyProvider = EncryptionKeyProvider.of(settings);
-            this.repositoryStorageIOProvider =
-                    createRepositoryStorageIOProvider(
-                            repositoryType,
-                            settings,
-                            encryptionKeyProvider
-                    );
+            this.repositoryStorageIOProvider = createRepositoryStorageIOProvider(settings);
         } catch (final Exception e) {
             throw new IOException(e.getMessage(), e);
         }
     }
 
-    protected abstract RepositoryStorageIOProvider<T> createRepositoryStorageIOProvider(
-            final String repositoryType, final Settings settings, final EncryptionKeyProvider encryptionKeyProvider)
-                throws IOException;
+    protected abstract RepositoryStorageIOProvider<T> createRepositoryStorageIOProvider(final Settings settings)
+            throws IOException;
 
 }

--- a/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/security/EncryptionKeyProvider.java
+++ b/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/security/EncryptionKeyProvider.java
@@ -22,19 +22,13 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Objects;
 
-import io.aiven.elasticsearch.repositories.Permissions;
-
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.elasticsearch.common.settings.SecureSetting;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,12 +38,6 @@ public final class EncryptionKeyProvider
     private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionKeyProvider.class);
 
     public static final int KEY_SIZE = 256;
-
-    public static final Setting<InputStream> PUBLIC_KEY_FILE =
-            SecureSetting.secureFile("aiven.public_key_file", null);
-
-    public static final Setting<InputStream> PRIVATE_KEY_FILE =
-            SecureSetting.secureFile("aiven.private_key_file", null);
 
     private static final String CIPHER_TRANSFORMATION = "RSA/NONE/OAEPWithSHA3-512AndMGF1Padding";
 
@@ -61,21 +49,6 @@ public final class EncryptionKeyProvider
                                   final KeyGenerator aesKeyGenerator) {
         this.rsaKeyPair = rsaKeyPair;
         this.aesKeyGenerator = aesKeyGenerator;
-    }
-
-    public static EncryptionKeyProvider of(final Settings settings) throws IOException {
-        return Permissions.doPrivileged(() -> {
-            Objects.requireNonNull(settings, "settings hasn't been set");
-            if (!PUBLIC_KEY_FILE.exists(settings)) {
-                throw new IllegalArgumentException(
-                        "Settings with name " + PUBLIC_KEY_FILE.getKey() + " hasn't been set");
-            }
-            if (!PRIVATE_KEY_FILE.exists(settings)) {
-                throw new IllegalArgumentException(
-                        "Settings with name " + PRIVATE_KEY_FILE.getKey() + " hasn't been set");
-            }
-            return of(PUBLIC_KEY_FILE.get(settings), PRIVATE_KEY_FILE.get(settings));
-        });
     }
 
     public static EncryptionKeyProvider of(final InputStream rsaPublicKey,

--- a/repository-commons/src/test/java/io/aiven/elasticsearch/repositories/security/EncryptionKeyProviderTest.java
+++ b/repository-commons/src/test/java/io/aiven/elasticsearch/repositories/security/EncryptionKeyProviderTest.java
@@ -19,10 +19,8 @@ package io.aiven.elasticsearch.repositories.security;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import io.aiven.elasticsearch.repositories.DummySecureSettings;
 import io.aiven.elasticsearch.repositories.RsaKeyAwareTest;
 
-import org.elasticsearch.common.settings.Settings;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,23 +49,6 @@ public class EncryptionKeyProviderTest extends RsaKeyAwareTest {
                         Files.newInputStream(publicKeyPem),
                         Files.newInputStream(privateKeyPem)
                 );
-        final var secretKey = ekProvider.createKey();
-        final var encryptedKey = ekProvider.encryptKey(secretKey);
-        final var restoredKey = ekProvider.decryptKey(encryptedKey);
-
-        assertEquals(secretKey, restoredKey);
-    }
-
-    @Test
-    public void canBeBuildFromElasticSettings() throws IOException {
-        final var settings = Settings.builder().setSecureSettings(
-                new DummySecureSettings()
-                        .setFile(EncryptionKeyProvider.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
-                        .setFile(EncryptionKeyProvider.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem))
-        ).build();
-
-
-        final var ekProvider = EncryptionKeyProvider.of(settings);
         final var secretKey = ekProvider.createKey();
         final var encryptedKey = ekProvider.encryptKey(secretKey);
         final var restoredKey = ekProvider.decryptKey(encryptedKey);

--- a/repository-gcs/src/integration-test/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryPluginIT.java
+++ b/repository-gcs/src/integration-test/java/io/aiven/elasticsearch/repositories/gcs/GcsRepositoryPluginIT.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import io.aiven.elasticsearch.repositories.DummySecureSettings;
 import io.aiven.elasticsearch.repositories.RepositoryStorageIOProvider;
 import io.aiven.elasticsearch.repositories.RsaKeyAwareTest;
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 import com.google.auth.oauth2.UserCredentials;
 import com.google.cloud.storage.Blob;
@@ -81,8 +80,8 @@ class GcsRepositoryPluginIT extends RsaKeyAwareTest {
                 securitySettings
                         .setFile(GcsStorageSettings.CREDENTIALS_FILE_SETTING.getKey(),
                                 Files.newInputStream(gcsCredentialsPath))
-                        .setFile(EncryptionKeyProvider.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
-                        .setFile(EncryptionKeyProvider.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
+                        .setFile(GcsStorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
+                        .setFile(GcsStorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
             } catch (final IOException e) {
                 throw new RuntimeException(e);
             }

--- a/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsRepositoryPlugin.java
+++ b/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsRepositoryPlugin.java
@@ -33,8 +33,10 @@ public class GcsRepositoryPlugin extends AbstractRepositoryPlugin<Storage>  {
     }
 
     @Override
-    protected List<Setting<?>> getPluginSettings() {
+    public List<Setting<?>> getSettings() {
         return List.of(
+                GcsStorageSettings.PRIVATE_KEY_FILE,
+                GcsStorageSettings.PUBLIC_KEY_FILE,
                 GcsStorageSettings.CREDENTIALS_FILE_SETTING,
                 GcsStorageSettings.PROJECT_ID,
                 GcsStorageSettings.CONNECTION_TIMEOUT,

--- a/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsRepositoryStorageIOProvider.java
+++ b/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsRepositoryStorageIOProvider.java
@@ -50,10 +50,9 @@ public class GcsRepositoryStorageIOProvider
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcsRepositoryStorageIOProvider.class);
 
-    public GcsRepositoryStorageIOProvider(final String repositoryType,
-                                          final Storage client,
+    public GcsRepositoryStorageIOProvider(final Storage client,
                                           final EncryptionKeyProvider encryptionKeyProvider) {
-        super(repositoryType, client, encryptionKeyProvider);
+        super(GcsRepositoryPlugin.REPOSITORY_TYPE, client, encryptionKeyProvider);
     }
 
     @Override

--- a/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsStorageSettings.java
+++ b/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsStorageSettings.java
@@ -36,16 +36,29 @@ public class GcsStorageSettings implements CommonSettings.KeystoreSettings {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcsStorageSettings.class);
 
+    public static final Setting<InputStream> PUBLIC_KEY_FILE =
+            SecureSetting.secureFile(withPrefix("gcs.public_key_file"), null);
+
+    public static final Setting<InputStream> PRIVATE_KEY_FILE =
+            SecureSetting.secureFile(withPrefix("gcs.private_key_file"), null);
+
     public static final Setting<InputStream> CREDENTIALS_FILE_SETTING =
             SecureSetting.secureFile(withPrefix("gcs.client.credentials_file"), null);
+
     public static final Setting<String> PROJECT_ID =
             Setting.simpleString(withPrefix("gcs.client.project_id"), Setting.Property.NodeScope);
+
     public static final Setting<Integer> CONNECTION_TIMEOUT =
             Setting.intSetting(withPrefix("gcs.client.connection_timeout"), -1, -1,
                     Setting.Property.NodeScope);
+
     public static final Setting<Integer> READ_TIMEOUT =
             Setting.intSetting(withPrefix("gcs.client.read_timeout"), -1, -1,
                     Setting.Property.NodeScope);
+
+    private final InputStream publicKey;
+
+    private final InputStream privateKey;
 
     private final String projectId;
 
@@ -55,10 +68,14 @@ public class GcsStorageSettings implements CommonSettings.KeystoreSettings {
 
     private final int readTimeout;
 
-    private GcsStorageSettings(final String projectId,
+    private GcsStorageSettings(final InputStream publicKey,
+                               final InputStream privateKey,
+                               final String projectId,
                                final GoogleCredentials gcsCredentials,
                                final int connectionTimeout,
                                final int readTimeout) {
+        this.publicKey = publicKey;
+        this.privateKey = privateKey;
         this.projectId = projectId;
         this.gcsCredentials = gcsCredentials;
         this.connectionTimeout = connectionTimeout;
@@ -69,7 +86,15 @@ public class GcsStorageSettings implements CommonSettings.KeystoreSettings {
         if (settings.isEmpty()) {
             throw new IllegalArgumentException("Settings for GC storage hasn't been set");
         }
+        if (!PUBLIC_KEY_FILE.exists(settings)) {
+            throw new IllegalArgumentException("Settings with name " + PUBLIC_KEY_FILE.getKey() + " hasn't been set");
+        }
+        if (!PRIVATE_KEY_FILE.exists(settings)) {
+            throw new IllegalArgumentException("Settings with name " + PRIVATE_KEY_FILE.getKey() + " hasn't been set");
+        }
         return new GcsStorageSettings(
+                PUBLIC_KEY_FILE.get(settings),
+                PRIVATE_KEY_FILE.get(settings),
                 PROJECT_ID.get(settings),
                 loadCredentials(settings),
                 CONNECTION_TIMEOUT.get(settings),
@@ -90,6 +115,14 @@ public class GcsStorageSettings implements CommonSettings.KeystoreSettings {
             return setting.get(settings);
         }
         throw new IllegalArgumentException("Settings with name " + setting.getKey() + " hasn't been set");
+    }
+
+    public InputStream publicKey() {
+        return publicKey;
+    }
+
+    public InputStream privateKey() {
+        return privateKey;
     }
 
     public String projectId() {

--- a/repository-gcs/src/test/java/io.aiven.elasticsearch.repositories.gcs/GcsSettingsProviderTest.java
+++ b/repository-gcs/src/test/java/io.aiven.elasticsearch.repositories.gcs/GcsSettingsProviderTest.java
@@ -23,7 +23,6 @@ import io.aiven.elasticsearch.repositories.CommonSettings;
 import io.aiven.elasticsearch.repositories.DummySecureSettings;
 import io.aiven.elasticsearch.repositories.RepositoryStorageIOProvider;
 import io.aiven.elasticsearch.repositories.RsaKeyAwareTest;
-import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.UserCredentials;
@@ -153,19 +152,19 @@ class GcsSettingsProviderTest extends RsaKeyAwareTest {
         e = assertThrows(IOException.class, () ->
                 gcsSettingsProvider.reload(GcsRepositoryPlugin.REPOSITORY_TYPE, anySettings));
         assertEquals(
-                "Settings with name aiven.public_key_file hasn't been set",
+                "Settings with name aiven.gcs.public_key_file hasn't been set",
                 e.getMessage());
 
         e = assertThrows(IOException.class, () ->
                 gcsSettingsProvider.reload(GcsRepositoryPlugin.REPOSITORY_TYPE, privateRsaKeyOnlySettings));
         assertEquals(
-                "Settings with name aiven.public_key_file hasn't been set",
+                "Settings with name aiven.gcs.public_key_file hasn't been set",
                 e.getMessage());
 
         e = assertThrows(IOException.class, () ->
                 gcsSettingsProvider.reload(GcsRepositoryPlugin.REPOSITORY_TYPE, publicRsaKeyOnlySettings));
         assertEquals(
-                "Settings with name aiven.private_key_file hasn't been set",
+                "Settings with name aiven.gcs.private_key_file hasn't been set",
                 e.getMessage());
 
     }
@@ -183,8 +182,8 @@ class GcsSettingsProviderTest extends RsaKeyAwareTest {
                 .setFile(
                         GcsStorageSettings.CREDENTIALS_FILE_SETTING.getKey(),
                         getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"))
-                .setFile(EncryptionKeyProvider.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem))
-                .setFile(EncryptionKeyProvider.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem));
+                .setFile(GcsStorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem))
+                .setFile(GcsStorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem));
     }
 
     private DummySecureSettings createPublicRsaKeyOnlySecureSettings() throws IOException {
@@ -192,7 +191,7 @@ class GcsSettingsProviderTest extends RsaKeyAwareTest {
                 .setFile(
                         GcsStorageSettings.CREDENTIALS_FILE_SETTING.getKey(),
                         getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"))
-                .setFile(EncryptionKeyProvider.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem));
+                .setFile(GcsStorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem));
     }
 
     private DummySecureSettings createPrivateRsaKeyOnlySecureSettings() throws IOException {
@@ -200,7 +199,7 @@ class GcsSettingsProviderTest extends RsaKeyAwareTest {
                 .setFile(
                         GcsStorageSettings.CREDENTIALS_FILE_SETTING.getKey(),
                         getClass().getClassLoader().getResourceAsStream("test_gcs_creds.json"))
-                .setFile(EncryptionKeyProvider.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
+                .setFile(GcsStorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
     }
 
     GoogleCredentials loadCredentials() throws IOException {

--- a/repository-gcs/src/test/java/io.aiven.elasticsearch.repositories.gcs/GcsStorageSettingsTest.java
+++ b/repository-gcs/src/test/java/io.aiven.elasticsearch.repositories.gcs/GcsStorageSettingsTest.java
@@ -75,7 +75,10 @@ class GcsStorageSettingsTest extends RsaKeyAwareTest {
                                         final InputStream publicKey,
                                         final InputStream privateKey) throws IOException {
         return new DummySecureSettings()
-                .setFile(GcsStorageSettings.CREDENTIALS_FILE_SETTING.getKey(), googleCredential);
+                .setFile(GcsStorageSettings.CREDENTIALS_FILE_SETTING.getKey(), googleCredential)
+                .setFile(GcsStorageSettings.PUBLIC_KEY_FILE.getKey(), publicKey)
+                .setFile(GcsStorageSettings.PRIVATE_KEY_FILE.getKey(), privateKey);
+
     }
 
 }


### PR DESCRIPTION
For ES all keystore setting names must be unique per node.                     
This means that current solution doesn't work properly in ES.
E.g. it is impossible to use 2 different plugins with the same settings name.  
