### PR TITLE
Add support for SOCKS proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,11 +124,11 @@ allprojects {
 
         compile "org.slf4j:slf4j-api:$slf4jVersion"
 
-        testCompile "org.mockito:mockito-core:3.5.7"
-        testCompile "org.mockito:mockito-junit-jupiter:3.5.7"
-        testCompile "org.codelibs:elasticsearch-cluster-runner:$elasticClusterRunnerVersion"
-
+        testImplementation "org.mockito:mockito-core:3.5.7"
+        testImplementation "org.mockito:mockito-junit-jupiter:3.5.7"
+        testImplementation "org.codelibs:elasticsearch-cluster-runner:$elasticClusterRunnerVersion"
         testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
+
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 
         // Make test utils from 'test' available in 'integration-test'

--- a/repository-gcs/build.gradle
+++ b/repository-gcs/build.gradle
@@ -15,7 +15,7 @@
  */
 
 ext {
-    gcsVerison = "1.113.1"
+    gcsVerison = "1.113.15"
 }
 
 dependencies {

--- a/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsRepositoryPlugin.java
+++ b/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsRepositoryPlugin.java
@@ -40,7 +40,11 @@ public class GcsRepositoryPlugin extends AbstractRepositoryPlugin<Storage>  {
                 GcsStorageSettings.CREDENTIALS_FILE_SETTING,
                 GcsStorageSettings.PROJECT_ID,
                 GcsStorageSettings.CONNECTION_TIMEOUT,
-                GcsStorageSettings.READ_TIMEOUT
+                GcsStorageSettings.READ_TIMEOUT,
+                GcsStorageSettings.PROXY_HOST,
+                GcsStorageSettings.PROXY_PORT,
+                GcsStorageSettings.PROXY_USER_NAME,
+                GcsStorageSettings.PROXY_USER_PASSWORD
         );
     }
 

--- a/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsSettingsProvider.java
+++ b/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsSettingsProvider.java
@@ -17,6 +17,10 @@
 package io.aiven.elasticsearch.repositories.gcs;
 
 import java.io.IOException;
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
 import java.util.Map;
 
 import io.aiven.elasticsearch.repositories.Permissions;
@@ -24,12 +28,17 @@ import io.aiven.elasticsearch.repositories.RepositorySettingsProvider;
 import io.aiven.elasticsearch.repositories.RepositoryStorageIOProvider;
 import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.auth.http.HttpTransportFactory;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Strings;
 import com.google.common.net.HttpHeaders;
 import org.elasticsearch.common.settings.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GcsSettingsProvider extends RepositorySettingsProvider<Storage> {
 
@@ -58,6 +67,7 @@ public class GcsSettingsProvider extends RepositorySettingsProvider<Storage> {
         storageOptionsBuilder
                 .setTransportOptions(
                         HttpTransportOptions.newBuilder()
+                                .setHttpTransportFactory(createHttpTransportFactory(gcsStorageSettings))
                                 .setConnectTimeout(gcsStorageSettings.connectionTimeout())
                                 .setReadTimeout(gcsStorageSettings.readTimeout())
                                 .build())
@@ -67,5 +77,61 @@ public class GcsSettingsProvider extends RepositorySettingsProvider<Storage> {
         return storageOptionsBuilder.build().getService();
     }
 
+    private HttpTransportFactory createHttpTransportFactory(final GcsStorageSettings gcsStorageSettings) {
+        if (!Strings.isNullOrEmpty(gcsStorageSettings.getProxyHost())) {
+            return new ProxyHttpTransportFactory(
+                    gcsStorageSettings.getProxyHost(),
+                    gcsStorageSettings.getProxyPort(),
+                    gcsStorageSettings.getProxyUsername(),
+                    gcsStorageSettings.getProxyUserPassword()
+            );
+        }
+        return new HttpTransportOptions.DefaultHttpTransportFactory();
+    }
+
+    public static final class ProxyHttpTransportFactory extends HttpTransportOptions.DefaultHttpTransportFactory {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(GcsSettingsProvider.class);
+
+        private final String proxyHost;
+
+        private final int proxyPort;
+
+        private final String proxyUsername;
+
+        private final char[] proxyUserPassword;
+
+        public ProxyHttpTransportFactory(final String proxyHost,
+                                         final int proxyPort,
+                                         final String proxyUsername,
+                                         final char[] proxyUserPassword) {
+            this.proxyHost = proxyHost;
+            this.proxyPort = proxyPort;
+            this.proxyUsername = proxyUsername;
+            this.proxyUserPassword = proxyUserPassword;
+        }
+
+        @Override
+        public HttpTransport create() {
+            LOGGER.info("Create HttpTransportFactory with proxy support. Host: {} and port: {}", proxyHost, proxyPort);
+            if (!Strings.isNullOrEmpty(proxyUsername)
+                    && !Strings.isNullOrEmpty(String.valueOf(proxyUserPassword))) {
+                LOGGER.info("Set user/pwd Authenticator: user is {} and pwd {}",
+                        proxyUsername,
+                        proxyUserPassword.length  == 0 ? "is empty" : "is not empty");
+                Authenticator.setDefault(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(proxyUsername, proxyUserPassword);
+                    }
+                });
+                return new NetHttpTransport.Builder()
+                        .setProxy(new Proxy(Proxy.Type.SOCKS,
+                        new InetSocketAddress(proxyHost, proxyPort))).build();
+            } else {
+                return new NetHttpTransport();
+            }
+        }
+    }
 
 }

--- a/repository-gcs/src/main/resources/plugin-security.policy
+++ b/repository-gcs/src/main/resources/plugin-security.policy
@@ -1,5 +1,7 @@
 grant {
 
+  permission java.net.NetPermission "setDefaultAuthenticator";
+
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 
   permission java.lang.RuntimePermission "loadLibrary.*";


### PR DESCRIPTION
Added 4 new settings to set up SOCKS proxy:
 - `aiven.gcs.client.proxy.host`
 - `aiven.gcs.client.proxy.port`
 - `aiven.gcs.client.proxy.user_name`
 - `aiven.gcs.client.proxy.user_password`