### PR TITLE
Fix integration tests

### DIFF
--- a/repository-azure/build.gradle
+++ b/repository-azure/build.gradle
@@ -100,6 +100,9 @@ task integrationTest(type: Test) {
 
     useJUnitPlatform()
 
+    minHeapSize "1024m"
+    maxHeapSize "1024m"
+
     // Run always.
     outputs.upToDateWhen { false }
 

--- a/repository-gcs/build.gradle
+++ b/repository-gcs/build.gradle
@@ -76,6 +76,9 @@ task integrationTest(type: Test) {
 
     useJUnitPlatform()
 
+    minHeapSize = "1024m"
+    maxHeapSize = "1024m"
+
     // Run always.
     outputs.upToDateWhen { false }
 

--- a/repository-s3/build.gradle
+++ b/repository-s3/build.gradle
@@ -80,6 +80,9 @@ task integrationTest(type: Test) {
 
     useJUnitPlatform()
 
+    minHeapSize = "1024m"
+    maxHeapSize = "1024m"
+
     // Run always.
     outputs.upToDateWhen { false }
 


### PR DESCRIPTION
The integration tests we not able to run due to too low heap size set for the JVM running the tests. Added `minHeapSize` and `maxHeapSize` to each of the plugin's `gradle.build` file as apparently that setting was not used from the main build file.