### PR TITLE
Allow reloading S3 endpoint configuration without server restart

### DIFF
--- a/repository-s3/src/integration-test/java/io/aiven/elasticsearch/repositories/s3/S3RepositoryPluginIT.java
+++ b/repository-s3/src/integration-test/java/io/aiven/elasticsearch/repositories/s3/S3RepositoryPluginIT.java
@@ -64,6 +64,9 @@ public class S3RepositoryPluginIT extends AbstractRepositoryPluginIT {
                                         .setString(
                                                 S3StorageSettings.AWS_SECRET_ACCESS_KEY.getKey(),
                                                 awsSecretAccessKey)
+                                        .setString(
+                                                S3StorageSettings.ENDPOINT.getKey(),
+                                                awsEndpoint)
                                         .setFile(
                                                 S3StorageSettings.PUBLIC_KEY_FILE.getKey(),
                                                 Files.newInputStream(publicKeyPem))

--- a/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3StorageSettings.java
+++ b/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3StorageSettings.java
@@ -46,8 +46,8 @@ public class S3StorageSettings implements KeystoreSettings {
     public static final Setting<SecureString> AWS_ACCESS_KEY_ID =
             SecureSetting.secureString(withPrefix("s3.client.aws_access_key_id"), null);
 
-    public static final Setting<String> ENDPOINT =
-            Setting.simpleString(withPrefix("s3.client.endpoint"), Setting.Property.NodeScope);
+    public static final Setting<SecureString> ENDPOINT =
+            SecureSetting.secureString(withPrefix("s3.client.endpoint"), null);
 
     public static final Setting<Integer> MAX_RETRIES =
             Setting.intSetting(
@@ -142,7 +142,7 @@ public class S3StorageSettings implements KeystoreSettings {
                         AWS_ACCESS_KEY_ID.get(settings).toString(),
                         AWS_SECRET_ACCESS_KEY.get(settings).toString()
                 ),
-                ENDPOINT.get(settings),
+                ENDPOINT.get(settings).toString(),
                 MAX_RETRIES.get(settings),
                 USE_THROTTLE_RETRIES.get(settings),
                 READ_TIMEOUT.get(settings).millis());

--- a/repository-s3/src/test/java/io/aiven/elasticsearch/repositories/s3/S3SettingsProviderTest.java
+++ b/repository-s3/src/test/java/io/aiven/elasticsearch/repositories/s3/S3SettingsProviderTest.java
@@ -52,12 +52,12 @@ class S3SettingsProviderTest extends RsaKeyAwareTest {
                 new DummySecureSettings()
                         .setString(S3StorageSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
                         .setString(S3StorageSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
+                        .setString(S3StorageSettings.ENDPOINT.getKey(), "http://endpoint")
                         .setFile(S3StorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
                         .setFile(S3StorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
 
         final var settings =
                 Settings.builder()
-                        .put(S3StorageSettings.ENDPOINT.getKey(), "http://endpoint")
                         .put(S3StorageSettings.MAX_RETRIES.getKey(), 12)
                         .put(S3StorageSettings.READ_TIMEOUT.getKey(), TimeValue.timeValueMillis(1000L))
                         .put(S3StorageSettings.USE_THROTTLE_RETRIES.getKey(), false)
@@ -86,14 +86,12 @@ class S3SettingsProviderTest extends RsaKeyAwareTest {
                 new DummySecureSettings()
                         .setString(S3StorageSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
                         .setString(S3StorageSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
+                        .setString(S3StorageSettings.ENDPOINT.getKey(), "http://endpoint")
                         .setFile(S3StorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
                         .setFile(S3StorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
 
         final var settings =
-                Settings.builder()
-                        .put(S3StorageSettings.ENDPOINT.getKey(), "http://endpoint")
-                        .setSecureSettings(secureSettings)
-                        .build();
+                Settings.builder().setSecureSettings(secureSettings).build();
 
         s3SettingsProvider.reload(S3RepositoryPlugin.REPOSITORY_TYPE, settings);
 

--- a/repository-s3/src/test/java/io/aiven/elasticsearch/repositories/s3/S3StorageSettingsTest.java
+++ b/repository-s3/src/test/java/io/aiven/elasticsearch/repositories/s3/S3StorageSettingsTest.java
@@ -55,11 +55,11 @@ class S3StorageSettingsTest extends RsaKeyAwareTest {
         final var secureSettings =
                 new DummySecureSettings()
                         .setString(S3StorageSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
+                        .setString(S3StorageSettings.ENDPOINT.getKey(), "ENDPOINT")
                         .setFile(S3StorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
                         .setFile(S3StorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
 
-        final var noAwsAccessKeyId = Settings.builder().put(S3StorageSettings.ENDPOINT.getKey(), "endpoint")
-                .setSecureSettings(secureSettings).build();
+        final var noAwsAccessKeyId = Settings.builder().setSecureSettings(secureSettings).build();
 
         final var t =
                 assertThrows(IllegalArgumentException.class, () -> S3StorageSettings.create(noAwsAccessKeyId));
@@ -74,11 +74,11 @@ class S3StorageSettingsTest extends RsaKeyAwareTest {
         final var secureSettings =
                 new DummySecureSettings()
                         .setString(S3StorageSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
+                        .setString(S3StorageSettings.ENDPOINT.getKey(), "ENDPOINT")
                         .setFile(S3StorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
                         .setFile(S3StorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
 
-        final var noAwsAccessKeyId = Settings.builder().put(S3StorageSettings.ENDPOINT.getKey(), "endpoint")
-                .setSecureSettings(secureSettings).build();
+        final var noAwsAccessKeyId = Settings.builder().setSecureSettings(secureSettings).build();
 
         final var t =
                 assertThrows(IllegalArgumentException.class, () -> S3StorageSettings.create(noAwsAccessKeyId));
@@ -95,6 +95,7 @@ class S3StorageSettingsTest extends RsaKeyAwareTest {
                 new DummySecureSettings()
                         .setString(S3StorageSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
                         .setString(S3StorageSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
+                        .setString(S3StorageSettings.ENDPOINT.getKey(), "ENDPOINT")
                         .setFile(S3StorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
         final var t =
                 assertThrows(IllegalArgumentException.class, () ->
@@ -110,6 +111,7 @@ class S3StorageSettingsTest extends RsaKeyAwareTest {
                 new DummySecureSettings()
                         .setString(S3StorageSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
                         .setString(S3StorageSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
+                        .setString(S3StorageSettings.ENDPOINT.getKey(), "ENDPOINT")
                         .setFile(S3StorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem));
         final var t =
                 assertThrows(IllegalArgumentException.class, () ->
@@ -124,12 +126,12 @@ class S3StorageSettingsTest extends RsaKeyAwareTest {
                 new DummySecureSettings()
                         .setString(S3StorageSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
                         .setString(S3StorageSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
+                        .setString(S3StorageSettings.ENDPOINT.getKey(), "endpoint")
                         .setFile(S3StorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
                         .setFile(S3StorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
 
         final var settings =
-                Settings.builder().put(S3StorageSettings.ENDPOINT.getKey(), "endpoint")
-                        .setSecureSettings(secureSettings).build();
+                Settings.builder().setSecureSettings(secureSettings).build();
 
         final var s3StorageSettings = S3StorageSettings.create(settings);
 
@@ -147,12 +149,12 @@ class S3StorageSettingsTest extends RsaKeyAwareTest {
                 new DummySecureSettings()
                         .setString(S3StorageSettings.AWS_ACCESS_KEY_ID.getKey(), "AWS_ACCESS_KEY_ID")
                         .setString(S3StorageSettings.AWS_SECRET_ACCESS_KEY.getKey(), "AWS_SECRET_ACCESS_KEY")
+                        .setString(S3StorageSettings.ENDPOINT.getKey(), "http://endpoint")
                         .setFile(S3StorageSettings.PUBLIC_KEY_FILE.getKey(), Files.newInputStream(publicKeyPem))
                         .setFile(S3StorageSettings.PRIVATE_KEY_FILE.getKey(), Files.newInputStream(privateKeyPem));
 
         final var settings =
                 Settings.builder()
-                        .put(S3StorageSettings.ENDPOINT.getKey(), "http://endpoint")
                         .put(S3StorageSettings.MAX_RETRIES.getKey(), 12)
                         .put(S3StorageSettings.READ_TIMEOUT.getKey(), TimeValue.timeValueMillis(1000L))
                         .put(S3StorageSettings.USE_THROTTLE_RETRIES.getKey(), false)


### PR DESCRIPTION
The S3 endpoint setting was loaded from `elasticsearch.yml` configuration file. This did not allow changing it without restarting the server. This PR moves this setting from configuration file under "secure settings" that can be loaded without restarting the server. 