### PR TITLE
S3 azure socks support

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -19,4 +19,6 @@
         "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+    <suppress checks="(ParameterNumber)"
+              files="(S3StorageSettings).java"/>
 </suppressions>

--- a/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureStorageSettings.java
+++ b/repository-azure/src/main/java/io/aiven/elasticsearch/repositories/azure/AzureStorageSettings.java
@@ -58,6 +58,19 @@ public class AzureStorageSettings implements CommonSettings.KeystoreSettings {
     public static final Setting<SecureString> AZURE_ACCOUNT_KEY =
             SecureSetting.secureString(withPrefix("azure.client.account.key"), null);
 
+    public static final Setting<String> PROXY_HOST =
+            Setting.simpleString(withPrefix("azure.client.proxy.host"), Setting.Property.NodeScope);
+
+    public static final Setting<Integer> PROXY_PORT =
+            SecureSetting.intSetting(withPrefix("azure.client.proxy.port"), 1080, 0,
+                    Setting.Property.NodeScope);
+
+    public static final Setting<SecureString> PROXY_USER_NAME =
+            SecureSetting.secureString(withPrefix("azure.client.proxy.user_name"), null);
+
+    public static final Setting<SecureString> PROXY_USER_PASSWORD =
+            SecureSetting.secureString(withPrefix("azure.client.proxy.user_password"), null);
+
     //default is 3 please take a look ExponentialBackoff azure class
     public static final Setting<Integer> MAX_RETRIES =
             Setting.intSetting(withPrefix("max_retries"), 3, Setting.Property.NodeScope);
@@ -72,6 +85,14 @@ public class AzureStorageSettings implements CommonSettings.KeystoreSettings {
 
     private final int maxRetries;
 
+    private final String proxyHost;
+
+    private final int proxyPort;
+
+    private final String proxyUsername;
+
+    private final char[] proxyUserPassword;
+
     private final HttpThreadPoolSettings httpThreadPoolSettings;
 
     AzureStorageSettings(final InputStream publicKey,
@@ -79,12 +100,20 @@ public class AzureStorageSettings implements CommonSettings.KeystoreSettings {
                          final String azureAccount,
                          final String azureAccountKey,
                          final int maxRetries,
+                         final String proxyHost,
+                         final int proxyPort,
+                         final String proxyUsername,
+                         final char[] proxyUserPassword,
                          final HttpThreadPoolSettings httpThreadPoolSettings) {
         this.publicKey = publicKey;
         this.privateKey = privateKey;
         this.azureAccount = azureAccount;
         this.azureAccountKey = azureAccountKey;
         this.maxRetries = maxRetries;
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
+        this.proxyUsername = proxyUsername;
+        this.proxyUserPassword = proxyUserPassword;
         this.httpThreadPoolSettings = httpThreadPoolSettings;
     }
 
@@ -112,6 +141,22 @@ public class AzureStorageSettings implements CommonSettings.KeystoreSettings {
         return maxRetries;
     }
 
+    public String proxyHost() {
+        return proxyHost;
+    }
+
+    public int proxyPort() {
+        return proxyPort;
+    }
+
+    public String proxyUsername() {
+        return proxyUsername;
+    }
+
+    public char[] proxyUserPassword() {
+        return proxyUserPassword;
+    }
+
     public static AzureStorageSettings create(final Settings settings) {
         checkSettings(AZURE_ACCOUNT, settings);
         checkSettings(AZURE_ACCOUNT_KEY, settings);
@@ -123,6 +168,10 @@ public class AzureStorageSettings implements CommonSettings.KeystoreSettings {
                 AZURE_ACCOUNT.get(settings).toString(),
                 AZURE_ACCOUNT_KEY.get(settings).toString(),
                 MAX_RETRIES.get(settings),
+                PROXY_HOST.get(settings),
+                PROXY_PORT.get(settings),
+                PROXY_USER_NAME.get(settings).toString(),
+                PROXY_USER_PASSWORD.get(settings).getChars(),
                 new HttpThreadPoolSettings(
                         AZURE_HTTP_POOL_MIN_THREADS.get(settings),
                         AZURE_HTTP_POOL_MAX_THREADS.get(settings),

--- a/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/CommonSettings.java
+++ b/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/CommonSettings.java
@@ -28,6 +28,8 @@ public interface CommonSettings {
 
         String AIVEN_PREFIX = "aiven";
 
+        int DEFAULT_SOCKS5_PORT = 1080;
+
         static String withPrefix(final String key) {
             return String.format("%s.%s", AIVEN_PREFIX, key);
         }

--- a/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/security/EncryptionKeyProvider.java
+++ b/repository-commons/src/main/java/io/aiven/elasticsearch/repositories/security/EncryptionKeyProvider.java
@@ -75,7 +75,7 @@ public final class EncryptionKeyProvider
             final var cipher = createEncryptingCipher(rsaKeyPair.getPublic(), CIPHER_TRANSFORMATION);
             return cipher.doFinal(secretKey.getEncoded());
         } catch (final IllegalBlockSizeException | BadPaddingException e) {
-            throw new RuntimeException("Couldn't encrypt AES key", e);
+            throw new RuntimeException("Couldn't encrypt the AES key", e);
         }
     }
 
@@ -84,7 +84,7 @@ public final class EncryptionKeyProvider
             final var cipher = createDecryptingCipher(rsaKeyPair.getPrivate(), CIPHER_TRANSFORMATION);
             return new SecretKeySpec(cipher.doFinal(bytes), "AES");
         } catch (final IllegalBlockSizeException | BadPaddingException e) {
-            throw new RuntimeException("Couldn't encrypt AES key", e);
+            throw new RuntimeException("Couldn't decrypt the AES key", e);
         }
     }
 

--- a/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsStorageSettings.java
+++ b/repository-gcs/src/main/java/io.aiven.elasticsearch.repositories.gcs/GcsStorageSettings.java
@@ -46,7 +46,7 @@ public class GcsStorageSettings implements CommonSettings.KeystoreSettings {
             Setting.simpleString(withPrefix("gcs.client.proxy.host"), Setting.Property.NodeScope);
 
     public static final Setting<Integer> PROXY_PORT =
-            SecureSetting.intSetting(withPrefix("gcs.client.proxy.port"), 0, 0,
+            SecureSetting.intSetting(withPrefix("gcs.client.proxy.port"), DEFAULT_SOCKS5_PORT, 0,
                     Setting.Property.NodeScope);
 
     public static final Setting<SecureString> PROXY_USER_NAME =

--- a/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3SettingsProvider.java
+++ b/repository-s3/src/main/java/io/aiven/elasticsearch/repositories/s3/S3SettingsProvider.java
@@ -17,6 +17,12 @@
 package io.aiven.elasticsearch.repositories.s3;
 
 import java.io.IOException;
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.Socket;
+import java.security.SecureRandom;
 
 import io.aiven.elasticsearch.repositories.Permissions;
 import io.aiven.elasticsearch.repositories.RepositorySettingsProvider;
@@ -26,8 +32,14 @@ import io.aiven.elasticsearch.repositories.security.EncryptionKeyProvider;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.http.SystemPropertyTlsKeyManagersProvider;
+import com.amazonaws.http.conn.ssl.SdkTLSSocketFactory;
+import com.amazonaws.internal.SdkSSLContext;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 
 public class S3SettingsProvider extends RepositorySettingsProvider<AmazonS3> {
@@ -47,8 +59,39 @@ public class S3SettingsProvider extends RepositorySettingsProvider<AmazonS3> {
 
     private AmazonS3 createClient(final S3StorageSettings s3KeystoreSettings) {
         final var s3ClientBuilder = AmazonS3ClientBuilder.standard();
-
         final var clientConfiguration = new ClientConfiguration();
+        if (!Strings.isNullOrEmpty(s3KeystoreSettings.proxyHost())) {
+            final var sslCtx = SdkSSLContext.getPreferredSSLContext(
+                    new SystemPropertyTlsKeyManagersProvider().getKeyManagers(),
+                    new SecureRandom());
+            clientConfiguration
+                    .getApacheHttpClientConfig()
+                    .setSslSocketFactory(
+                            // this settings is open question. need tio verify that it works ok
+                            new SdkTLSSocketFactory(sslCtx, SSLConnectionSocketFactory.STRICT_HOSTNAME_VERIFIER) {
+                                @Override
+                                public Socket createSocket(final HttpContext ctx) throws IOException {
+                                    return new Socket(
+                                            new Proxy(
+                                                    Proxy.Type.SOCKS,
+                                                    new InetSocketAddress(
+                                                            s3KeystoreSettings.proxyHost(),
+                                                            s3KeystoreSettings.proxyPort())));
+                                }
+                            });
+            if (!Strings.isNullOrEmpty(s3KeystoreSettings.proxyUsername())
+                    && !Strings.isNullOrEmpty(String.valueOf(s3KeystoreSettings.proxyUserPassword()))) {
+                Authenticator.setDefault(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(
+                                s3KeystoreSettings.proxyUsername(),
+                                s3KeystoreSettings.proxyUserPassword()
+                        );
+                    }
+                });
+            }
+        }
         clientConfiguration.setResponseMetadataCacheSize(0);
         clientConfiguration.setMaxErrorRetry(s3KeystoreSettings.maxRetries());
         clientConfiguration.setUseThrottleRetries(s3KeystoreSettings.useThrottleRetries());
@@ -57,10 +100,11 @@ public class S3SettingsProvider extends RepositorySettingsProvider<AmazonS3> {
 
         s3ClientBuilder
                 .withCredentials(new AWSStaticCredentialsProvider(s3KeystoreSettings.awsCredentials()))
-                .withClientConfiguration(clientConfiguration);
-        s3ClientBuilder.withEndpointConfiguration(
-                new AwsClientBuilder.EndpointConfiguration(
-                        s3KeystoreSettings.endpoint(), null));
+                .withClientConfiguration(clientConfiguration)
+                .withEndpointConfiguration(
+                        new AwsClientBuilder.EndpointConfiguration(
+                                s3KeystoreSettings.endpoint(),
+                                null));
         return s3ClientBuilder.build();
     }
 


### PR DESCRIPTION
Changes:
- Define default port for socks 5
- Set default port for SOCKS5 GCS plugin 
- Add support for SOCKS5 for S3 plugin
- Add support for SOCKS5 for Azure plugin